### PR TITLE
Downgrade spring-boot-starter-parent to 2.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.0.RELEASE</version>
+		<version>2.1.8.RELEASE</version>
 	</parent>
 
 	<dependencies>

--- a/src/test/java/net/pdp7/zqxjkcrud/SmokeTest.java
+++ b/src/test/java/net/pdp7/zqxjkcrud/SmokeTest.java
@@ -1,6 +1,6 @@
 package net.pdp7.zqxjkcrud;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
2.2.0 breaks operation behind reverse proxies (!)