### PR TITLE
Update spotless-maven-plugin and spring-boot-starter-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.3.RELEASE</version>
+		<version>2.3.4.RELEASE</version>
 	</parent>
 
 	<dependencies>
@@ -142,7 +142,7 @@
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
-				<version>2.3.1</version>
+				<version>2.4.0</version>
 				<configuration>
 					<java>
 						<googleJavaFormat>


### PR DESCRIPTION
Bump spotless-maven-plugin from 2.3.1 to 2.4.0

Bumps [spotless-maven-plugin](https://github.com/diffplug/project) from 2.3.1 to 2.4.0.
- [Release notes](https://github.com/diffplug/project/releases)
- [Commits](https://github.com/diffplug/project/commits)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Bump spring-boot-starter-parent from 2.3.3.RELEASE to 2.3.4.RELEASE

Bumps [spring-boot-starter-parent](https://github.com/spring-projects/spring-boot) from 2.3.3.RELEASE to 2.3.4.RELEASE.
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.3.3.RELEASE...v2.3.4.RELEASE)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>