### PR TITLE
Revert "Bump spring-boot-starter-parent from 2.5.7 to 2.6.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.1</version>
+		<version>2.5.7</version>
 	</parent>
 
 	<dependencies>


### PR DESCRIPTION
This reverts commit 87f18f058c8334bcd43f6beedde6fb5ba3d370e8.

See #256