### PR TITLE
Revert "Bump schemacrawler from 16.16.11 to 16.16.12"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<dependency>
 			<groupId>us.fatehi</groupId>
 			<artifactId>schemacrawler</artifactId>
-			<version>16.16.12</version>
+			<version>16.16.11</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This reverts commit bc60323e92760850475f41ea4481a595aba7bfb8.

schemacrawler.schemacrawler.exceptions.InternalRuntimeException: SchemaCrawler database plugin should be on the CLASSPATH for <jdbc:postgresql://...&currentSchema=zqxjk>, or the SC_WITHOUT_DATABASE_PLUGIN environmental variable should be set