### PR TITLE
chore: don't specify version of spotbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,15 +150,6 @@
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
 				<version>4.7.3.6</version>
-				<dependencies>
-					<!-- overwrite dependency on spotbugs if you want to specify the version 
-						of spotbugs -->
-					<dependency>
-						<groupId>com.github.spotbugs</groupId>
-						<artifactId>spotbugs</artifactId>
-						<version>4.7.3</version>
-					</dependency>
-				</dependencies>
 				<configuration>
 					<excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
 				</configuration>


### PR DESCRIPTION
Let's use the same version that the Maven plugin. Simpler, and I think there was some non-deterministic behavior...